### PR TITLE
Fixed issue with boolean "true_false"-fieldtype

### DIFF
--- a/lib/endpoints/class-acf-to-rest-api-controller.php
+++ b/lib/endpoints/class-acf-to-rest-api-controller.php
@@ -60,6 +60,19 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 				foreach ( $item['data'] as $key => $value ) {
 					if ( isset( $item['fields'][$key]['key'] ) ) {
 						$field = $item['fields'][$key];
+						$type = $field['type'];
+						
+						if($type == "true_false") {
+							switch ($value) {
+							    case "true":
+							        $value = 1;
+							        break;
+							    case "false":
+							        $value = 0;
+							        break;
+							}
+						}
+
 						if ( function_exists( 'acf_update_value' ) ) {
 							acf_update_value( $value, $item['id'], $field );
 						} elseif ( function_exists( 'update_field' ) ) {


### PR DESCRIPTION
Wrote a special case for "true_false"-field, because it only takes "1" for "true" and "0" for "false".