### PR TITLE
replace functions order in update_item method

### DIFF
--- a/lib/endpoints/class-acf-to-rest-api-controller.php
+++ b/lib/endpoints/class-acf-to-rest-api-controller.php
@@ -60,10 +60,10 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 				foreach ( $item['data'] as $key => $value ) {
 					if ( isset( $item['fields'][$key]['key'] ) ) {
 						$field = $item['fields'][$key];
-						if ( function_exists( 'acf_update_value' ) ) {
-							acf_update_value( $value, $item['id'], $field );
-						} elseif ( function_exists( 'update_field' ) ) {
+						if ( function_exists( 'update_field' ) ) {
 							update_field( $field['key'], $value, $item['id'] );
+						} elseif ( function_exists( 'acf_update_value' ) ) {
+							acf_update_value( $value, $item['id'], $field );
 						} else {
 							do_action( 'acf/update_value', $value, $item['id'], $field );
 						}


### PR DESCRIPTION
`acf_update_value` was deprecated in ACF version 4.
`update_field` should be the first option, and `acf_update_value` the second as fallback for older versions of ACF.