### PR TITLE
Add `acf` fields from relationships

### DIFF
--- a/lib/endpoints/class-acf-to-rest-api-controller.php
+++ b/lib/endpoints/class-acf-to-rest-api-controller.php
@@ -220,10 +220,29 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 				}
 			}
 
+			$this->add_relation_fields( $acf_data, $field );
+
+			if ( $field ) {
+				$data[ $field ] = $acf_data;
+			} else {
+				$data['acf'] = $acf_data;
+			}
+
+			if ( $swap ) {
+				$response->data = $data;
+				$data = $response;
+			}
+
+			return apply_filters( 'acf/rest_api/' . $this->type . '/get_fields', $data, $request, $response, $object );
+		}
+
+		protected function add_relation_fields( &$acf_data, $field ) {
 			foreach ( $acf_data as $k => $rel_array ) {
 				if ( is_array( $rel_array ) ) {
 					foreach ( $rel_array as $index => $rel_content ) {
 						$sub_acf_data = get_fields( $rel_content->ID );
+
+						$this->add_relation_fields( $sub_acf_data, $field );
 
 						if ( $field ) {
 							$rel_content->$field = $sub_acf_data;
@@ -233,19 +252,6 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 					}
 				}
 			}
-
-			if ( $field ) {
-				$data[ $field ] = $acf_data;
-			} else {
-				$data['acf'] = $acf_data;
-			}
-			
-			if ( $swap ) {
-				$response->data = $data;
-				$data = $response;
-			}
-
-			return apply_filters( 'acf/rest_api/' . $this->type . '/get_fields', $data, $request, $response, $object );
 		}
 
 		protected function get_field_objects( $id ) {

--- a/lib/endpoints/class-acf-to-rest-api-controller.php
+++ b/lib/endpoints/class-acf-to-rest-api-controller.php
@@ -182,7 +182,7 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 					$this->id = 'options';
 					break;
 			}
-			
+
 			$this->id = apply_filters( 'acf/rest_api/id', $this->id );
 
 			return $this->id;
@@ -196,7 +196,7 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 			if ( $request instanceof WP_REST_Request ) {
 				$field = $request->get_param( 'field' );
 			}
-			
+
 			if ( $swap ) {
 				$data = $response->get_data();
 			}

--- a/lib/endpoints/class-acf-to-rest-api-controller.php
+++ b/lib/endpoints/class-acf-to-rest-api-controller.php
@@ -220,11 +220,9 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 				}
 			}
 
-			foreach( $acf_data as $k => $rel_array ) {
-				if ( is_array($rel_array) )
-				{
-					foreach( $rel_array as $index => $rel_content )
-					{
+			foreach ( $acf_data as $k => $rel_array ) {
+				if ( is_array( $rel_array ) ) {
+					foreach ( $rel_array as $index => $rel_content ) {
 						$sub_acf_data = get_fields( $rel_content->ID );
 
 						if ( $field ) {

--- a/lib/endpoints/class-acf-to-rest-api-controller.php
+++ b/lib/endpoints/class-acf-to-rest-api-controller.php
@@ -211,14 +211,35 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 
 			$this->format_id( $object );
 
+			$acf_data = array();
 			if ( $this->id ) {
 				if ( $field ) {
-					$data = array( $field => get_field( $field, $this->id ) );
+					$acf_data = get_field( $field, $this->id );
 				} else {
-					$data['acf'] = get_fields( $this->id );
+					$acf_data = get_fields( $this->id );
 				}
+			}
+
+			foreach( $acf_data as $k => $rel_array ) {
+				if ( is_array($rel_array) )
+				{
+					foreach( $rel_array as $index => $rel_content )
+					{
+						$sub_acf_data = get_fields( $rel_content->ID );
+
+						if ( $field ) {
+							$rel_content->$field = $sub_acf_data;
+						} else {
+							$rel_content->acf = $sub_acf_data;
+						}
+					}
+				}
+			}
+
+			if ( $field ) {
+				$data[ $field ] = $acf_data;
 			} else {
-				$data['acf'] = array();
+				$data['acf'] = $acf_data;
 			}
 			
 			if ( $swap ) {


### PR DESCRIPTION
This feature was quickly discussed in airesvsg/acf-to-rest-api#94.

**Idea:** Expose `acf` fields from realtionships to the REST API as well.

**Solution:** Check for relationships in `get_fields` and fetch `acf` fields from all of them. This might be a performance issue for bigger objects, so it *could* be enabled via an option. The object is added to the relationship object with either the default key `acf` or the one set for the plugin.

**Enhancement ideas:**
* Add option for enabling fetching related `acf` fields which defaults to `false` in order to not break current API (while it shouldn't, because it's an additional field) as well as expected performance.
* I only use the free version of `acf` for now so I don't know whether this change will conflict with some other field that exposes an array. The enhancement could be to check for an `ID` key (and maybe more?)
* Recursively call the protected `get_fields`. Might be possible but I don't know much of WP internals so I might need help here.