### PR TITLE
Correct issue so ACF is able to send back term metadata

### DIFF
--- a/lib/endpoints/class-acf-to-rest-api-controller.php
+++ b/lib/endpoints/class-acf-to-rest-api-controller.php
@@ -215,7 +215,7 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 				if ( $field ) {
 					$data = array( $field => get_field( $field, $this->id ) );
 				} else {
-					$data['acf'] = get_fields( $this->id );
+					$data['acf'] = get_fields( $object );
 				}
 			} else {
 				$data['acf'] = array();


### PR DESCRIPTION
Issue: for terms, in the JSON's return, acf is set to false.
Fix: changing the parameter in ACF_To_REST_API_Controller's method get_fields($request, $response = null, $object = null): when calling ACF's get_fields() function, pass the $object instead of $this->id. It allows ACF to treat the data as a term and not as a post, making it able to retrieve its metadata