### PR TITLE
fix default params bug

### DIFF
--- a/v3/lib/endpoints/class-acf-to-rest-api-controller.php
+++ b/v3/lib/endpoints/class-acf-to-rest-api-controller.php
@@ -174,7 +174,7 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 			if ( $request instanceof WP_REST_Request ) {
 				$params = $request->get_params();
 				foreach ( self::$default_params as $k => $v ) {
-					if ( ! in_array( $k, $params ) ) {
+					if ( ! isset( $params[ $k ] ) ) {
 						$request->set_param( $k, $v );
 					}
 				}


### PR DESCRIPTION
I found the bug when i tried to limit "per_page" parameter at "/wp-json/acf/v3/{post-type} " endpoint.
When i tried "/wp-json/acf/v3/myposttype?per_page=-1" it didn't worked for me, so i found solution how to fix it.
In that case the "self::$default_params" is applies unconditionally to request parameters, so i fixed it.