### PR TITLE
Add action acf_to_rest_api_init to plugin init()

### DIFF
--- a/class-acf-to-rest-api.php
+++ b/class-acf-to-rest-api.php
@@ -26,6 +26,7 @@ if ( ! class_exists( 'ACF_To_REST_API' ) ) {
 
 		public static function init() {
 			self::includes();
+			do_action('acf_to_rest_api_init');
 			self::hooks();
 		}
 

--- a/class-acf-to-rest-api.php
+++ b/class-acf-to-rest-api.php
@@ -25,8 +25,8 @@ if ( ! class_exists( 'ACF_To_REST_API' ) ) {
 		private static $instance = null;
 
 		public static function init() {
+			do_action('acf_to_rest_api_custom_acf_loader');
 			self::includes();
-			do_action('acf_to_rest_api_init');
 			self::hooks();
 		}
 


### PR DESCRIPTION
https://github.com/airesvsg/acf-to-rest-api/issues/193

This is all I need. Then I can:

```
add_filter( 'acf_to_rest_api_init', function () {
	require_once( get_template_directory() . '/acf/acf.php' );
});
```

And the plugin is fixed! 🍾 