### PR TITLE
fix error Uncaught Error: Call to undefined method WP_Error::get_data()

### DIFF
--- a/v3/lib/endpoints/class-acf-to-rest-api-controller.php
+++ b/v3/lib/endpoints/class-acf-to-rest-api-controller.php
@@ -83,7 +83,13 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 				return new WP_Error( 'cant_get_items', __( 'Cannot get items', 'acf-to-rest-api' ), array( 'status' => 500 ) );
 			}
 
-			$this->set_default_parameters( $request );
+            $this->set_default_parameters( $request );
+            $items = $this->controller->get_items( $request );
+
+            if( !empty( $items->errors ) ) {
+                return new WP_Error(400,'Bad Request', $items->errors);
+            }
+
 			$data = $this->controller->get_items( $request )->get_data();
 
 			$response = array();


### PR DESCRIPTION
Added error output when pagination
```
[13-Apr-2020 09:07:11 UTC] PHP Fatal error:  Uncaught Error: Call to undefined method WP_Error::get_data() in /var/www/html/wp-content/plugins/acf-to-rest-api/v3/lib/endpoints/class-acf-to-rest-api-controller.php:87
Stack trace:
#0 /var/www/html/wp-content/plugins/acf-to-rest-api/v3/lib/endpoints/class-acf-to-rest-api-posts-controller.php(17): ACF_To_REST_API_Controller->get_items(Object(WP_REST_Request))
#1 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(1015): ACF_To_REST_API_Posts_Controller->get_items(Object(WP_REST_Request))
#2 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(342): WP_REST_Server->dispatch(Object(WP_REST_Request))
#3 /var/www/html/wp-includes/rest-api.php(306): WP_REST_Server->serve_request('/acf/v3/alerts')
#4 /var/www/html/wp-includes/class-wp-hook.php(287): rest_api_loaded(Object(WP))
#5 /var/www/html/wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters('', Array)
#6 /var/www/html/wp-includes/plugin.php(544): WP_Hook->do_action(Array)
#7 /var/www/html/wp-includes/class-wp.php(388): do_action_ref_arra in /var/www/html/wp-content/plugins/acf-to-rest-api/v3/lib/endpoints/class-acf-to-rest-api-controller.php on line 87
```
Before Error 500
![image](https://user-images.githubusercontent.com/37300581/79110972-43827680-7d84-11ea-9a1d-d67200aa799a.png)

After fix error we have Bad Request
![image](https://user-images.githubusercontent.com/37300581/79110729-bccd9980-7d83-11ea-9459-eb61724eef06.png)

![image](https://user-images.githubusercontent.com/37300581/79110750-c525d480-7d83-11ea-8e95-ae283fcd6c43.png)

