### PR TITLE
FIX: Fixes for uncaught error and the missing "X-WP-Total" & "X-WP-TotalPages" headers

### DIFF
--- a/v3/lib/endpoints/class-acf-to-rest-api-controller.php
+++ b/v3/lib/endpoints/class-acf-to-rest-api-controller.php
@@ -92,6 +92,14 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 					$items->get_error_data()
 				);
 			} else {
+				if (method_exists($items, 'get_headers')) {
+					$restServer = rest_get_server();
+					$headers = $items->get_headers();
+					foreach ($headers as $header => $value) {
+						$restServer->send_header($header, $value);
+					}
+				}
+				
 				if (method_exists($items, 'get_data')) {
 					$data = $items->get_data();
 				} else {

--- a/v3/lib/endpoints/class-acf-to-rest-api-controller.php
+++ b/v3/lib/endpoints/class-acf-to-rest-api-controller.php
@@ -84,7 +84,20 @@ if ( ! class_exists( 'ACF_To_REST_API_Controller' ) ) {
 			}
 
 			$this->set_default_parameters( $request );
-			$data = $this->controller->get_items( $request )->get_data();
+			$items = $this->controller->get_items( $request );
+			if (is_wp_error($items)) {
+				return new WP_Error(
+					$items->get_error_code(),
+					$items->get_error_message(),
+					$items->get_error_data()
+				);
+			} else {
+				if (method_exists($items, 'get_data')) {
+					$data = $items->get_data();
+				} else {
+					return new WP_Error( 'cant_get_items_data', __( 'Cannot get items data', 'acf-to-rest-api' ), array( 'status' => 500 ) );
+				}
+			}
 
 			$response = array();
 			if ( ! empty( $data ) ) {


### PR DESCRIPTION
Hello today I've found this issue when WP_REST_Posts_Controller->get_items() returned an WP_Error object but ACF_To_REST_API_Controller->get_items() didn't handle it. This can be reproduced when you exceed total posts in WP_REST_Posts_Controller line 351 for WP version 5.5.1. I think this issue is reproducible on older versions too.

So I've made a quick fix to handle WP_Error object to prevent breaking of the API.

Best regards,
Georgi!