### PR TITLE
Fix: Get field group with user_form rule

### DIFF
--- a/v3/lib/class-acf-to-rest-api-acf-api.php
+++ b/v3/lib/class-acf-to-rest-api-acf-api.php
@@ -131,7 +131,8 @@ if ( ! class_exists( 'ACF_To_REST_API_ACF_API' ) ) {
 			$fields_tmp = array();
 
 			if ( function_exists( 'acf_get_field_groups' ) && function_exists( 'acf_get_fields' ) && function_exists( 'acf_extract_var' ) ) {
-				$field_groups = acf_get_field_groups( array( 'post_id' => $id ) );
+
+				$field_groups = acf_get_field_groups( array( 'post_id' => $id, "user_form" => "all" ) );
 
 				if ( is_array( $field_groups ) && ! empty( $field_groups ) ) {
 					foreach ( $field_groups as $field_group ) {


### PR DESCRIPTION
If a field group has a user_form rule, it wasn´t able to be updated. acf_get_field_groups will never return any fields without whitelisting all user forms because only the id is passed. 

I think this change should not affect other functionality than updates for these specific field groups.

This could be related to #359 and #351 