### PR TITLE
fix: Issue with ACF 5.12

### DIFF
--- a/class-acf-to-rest-api.php
+++ b/class-acf-to-rest-api.php
@@ -67,10 +67,12 @@ if ( ! class_exists( 'ACF_To_REST_API' ) ) {
 		}
 
 		private static function hooks() {
-			add_action( 'init', array( __CLASS__, 'load_plugin_textdomain' ) );
+			$acf_plugin_version = get_option('acf_version');
+			$hook_type = $acf_plugin_version >= '5.12' ? 'rest_pre_dispatch' : 'rest_api_init';
 
+			add_action( 'init', array( __CLASS__, 'load_plugin_textdomain' ) );
 			if ( self::is_plugin_active( 'all' ) ) {
-				add_action( 'rest_api_init', array( __CLASS__, 'create_rest_routes' ), 10 );
+				add_action($hook_type, array( __CLASS__, 'create_rest_routes' ), 10 );
 				if ( self::$default_request_version == self::handle_request_version() ) {
 					ACF_To_REST_API_ACF_Field_Settings::hooks();
 				}


### PR DESCRIPTION
This PR fixes issue #398 caused by the recent introduction of the first-party REST API in ACF. This will keep backwards compatibility for older versions of ACF, but will use the new hook when applicable.